### PR TITLE
Add VisoRando gpx api call

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         tools:ignore="AllowBackup"

--- a/app/src/main/java/mobi/maptrek/VisoRandoApiCaller.java
+++ b/app/src/main/java/mobi/maptrek/VisoRandoApiCaller.java
@@ -1,0 +1,55 @@
+package mobi.maptrek;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import java.io.IOException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class VisoRandoApiCaller extends AsyncTask<String, Void, String> {
+
+    private Exception exception;
+
+    protected String doInBackground(String... urls) {
+        try {
+            String visoRandoUrl = "https://www.visorando.com/en/index.php?component=user&task=redirectToContent&from=gpxRando&idRandonnee=4098306";
+
+            OkHttpClient client = new OkHttpClient();
+            Request request = new Request.Builder()
+                    .url(visoRandoUrl)
+                    .get()
+                    .build();
+            try {
+                Response response = client.newCall(request).execute();
+                String php =  response.body().string();
+                int indexClickHere = php.indexOf("click here");
+                String line = php.substring(indexClickHere - 150, indexClickHere);
+                int indexHref = line.indexOf("href");
+                String gpxUrl = line.substring(indexHref + 6, line.length() - 2);
+
+                Request requestGpx = new Request.Builder()
+                        .url(gpxUrl)
+                        .get()
+                        .build();
+                Response responseGpx = client.newCall(requestGpx).execute();
+                String gpx = responseGpx.body().string();
+                return gpx;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } catch (Exception e) {
+            this.exception = e;
+
+            return null;
+        } finally {
+        }
+        return null;
+    }
+
+    protected void onPostExecute(String response) {
+        Log.d("POST EXECUTE VISORANDO",response);
+    }
+}

--- a/app/src/main/java/mobi/maptrek/fragments/ItineraryFragment.java
+++ b/app/src/main/java/mobi/maptrek/fragments/ItineraryFragment.java
@@ -15,13 +15,26 @@
  */
 
 package mobi.maptrek.fragments;
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import mobi.maptrek.R;
 
+import mobi.maptrek.R;
+import mobi.maptrek.VisoRandoApiCaller;
 
 public class ItineraryFragment extends Fragment {
     public ItineraryFragment() {
         super(R.layout.fragment_itinerary);
+    }
+
+    @MainThread
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        new VisoRandoApiCaller().execute();
+
     }
 }


### PR DESCRIPTION
Result from the api call as an example:
```
D/POST EXECUTE VISORANDO: <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
    <gpx version="1.1" creator="Visorando" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
D/POST EXECUTE VISORANDO: <metadata><name>The Tête Ronde Forest and Saint-Aubin Wood</name><link href=""><text></text></link></metadata><wpt lat="48.726739" lon="2.119374"><ele>151</ele><name>Entrance into the Tête Ronde Forest</name></wpt><wpt lat="48.728968" lon="2.109793"><ele>152</ele><name>Forest barrier</name></wpt><wpt lat="48.727627" lon="2.108621"><ele>106</ele><name>Junction with the PR</name></wpt><wpt lat="48.719272" lon="2.121445"><ele>93</ele><name>Route de Gif</name></wpt><wpt lat="48.715786" lon="2.121925"><ele>86</ele><name>Wooden bridge over the Mérantaise</name></wpt><wpt lat="48.714572" lon="2.124234"><ele>108</ele><name>Chemin du Moulin</name></wpt><wpt lat="48.71603" lon="2.129813"><ele>154</ele><name>Saclay Plateau</name></wpt><wpt lat="48.719263" lon="2.127255"><ele>157</ele><name>Saint-Aubin forest cemetery</name></wpt><trk><name>The Tête Ronde Forest and Saint-Aubin Wood</name><trkseg><trkpt lat="48.725706" lon="2.125586"><ele>152</ele></trkpt><trkpt lat="48.725741" lon="2.125329"><ele>151</ele></trkpt><trkpt lat="48.725932" lon="2.124621"><ele>148</ele></trkpt><trkpt lat="48.726152" lon="2.123955"><ele>146</ele></trkpt><trkpt lat="48.726293" lon="2.123666"><ele>146</ele></trkpt><trkpt lat="48.726527" lon="2.123355"><ele>149</ele></trkpt><trkpt lat="48.726746" lon="2.122239"><ele>149</ele></trkpt><trkpt lat="48.726944" lon="2.121316"><ele>149</ele></trkpt><trkpt lat="48.727086" lon="2.120908"><ele>149</ele></trkpt><trkpt lat="48.727397" lon="2.120351"><ele>150</ele></trkpt><trkpt lat="48.727539" lon="2.120072"><ele>150</ele></trkpt><trkpt lat="48.727574" lon="2.119814"><ele>150</ele></trkpt><trkpt lat="48.727532" lon="2.119514"><ele>151</ele></trkpt><trkpt lat="48.72744" lon="2.11931"><ele>151</ele></trkpt><trkpt lat="48.72727" lon="2.119192"><ele>151</ele></trkpt><trkpt lat="48.727079" lon="2.11917"><ele>151</ele></trkpt><trkpt lat="48.726923" lon="2.119203"><ele>152</ele></trkpt><trkpt lat="48.726739" lon="2.119374"><ele>151</ele></trkpt><trkpt lat="48.726527" lon="2.11931"><ele>152</ele></trkpt><trkpt lat="48.726392" lon="2.119149"><ele>154</ele></trkpt><trkpt lat="48.726399" lon="2.118881"><ele>156</ele></trkpt><trkpt lat="48.726456" lon="2.118548"><ele>157</ele></trkpt><trkpt lat="48.726336" lon="2.11784"><ele>160</ele></trkpt><trkpt lat="48.726134" lon="2.116635"><ele>163</ele></trkpt><trkpt lat="48.725897" lon="2.115222"><ele>161</ele></trkpt><trkpt lat="48.725794" lon="2.114629"><ele>160</ele></trkpt><trkpt lat="48.725801" lon="2.114425"><ele>160</ele></trkpt><trkpt lat="48.725967" lon="2.113913"><ele>158</ele></trkpt><trkpt lat="48.726067" lon="2.113613"><ele>158</ele></trkpt><trkpt lat="48.726204" lon="2.112676"><ele>157</ele></trkpt><trkpt lat="48.726148" lon="2.112108"><ele>151</ele></trkpt><trkpt lat="48.726647" lon="2.11121"><ele>146</ele></trkpt><trkpt lat="48.727397" lon="2.110845"><ele>147</ele></trkpt><trkpt lat="48.728275" lon="2.110394"><ele>148</ele></trkpt><trkpt lat="48.728671" lon="2.110265"><ele>151</ele></trkpt><trkpt lat="48.728968" lon="2.109793"><ele>152</ele></trkpt><trkpt lat="48.729379" lon="2.109193"><ele>154</ele></trkpt><trkpt lat="48.729747" lon="2.108592"><ele>153</ele></trkpt><trkpt lat="48.730016" lon="2.108055"><ele>154</ele></trkpt><trkpt lat="48.730143" lon="2.107733"><ele>152</ele></trkpt><trkpt lat="48.730157" lon="2.107454"><ele>150</ele></trkpt><trkpt lat="48.730341" lon="2.10709"><ele>148</ele></trkpt><trkpt lat="48.730532" lon="2.106736"><ele>148</ele></trkpt><trkpt lat="48.730511" lon="2.106543"><ele>146</ele></trkpt><trkpt lat="48.730327" lon="2.106639"><ele>142</ele></trkpt><trkpt lat="48.729952" lon="2.106779"><ele>136</ele></trkpt><trkpt lat="48.72974" lon="2.106939"><ele>133</ele></trkpt><trkpt lat="48.729442" lon="2.107261"><ele>129</ele></trkpt><trkpt lat="48.729018" lon="2.107712"><ele>125</ele></trkpt><trkpt lat="48.728735" lon="2.108034"><ele>123</ele></trkpt><trkpt lat="48.728452" lon="2.107948"><ele>114</ele></trkpt><trkpt lat="48.728275" lon="2.107969"><ele>110</ele></trkpt><trkpt lat="48.728105" lon="2.
```